### PR TITLE
Reduce input buffer size

### DIFF
--- a/ref/blake2.h
+++ b/ref/blake2.h
@@ -46,7 +46,7 @@ extern "C" {
     uint32_t h[8];
     uint32_t t[2];
     uint32_t f[2];
-    uint8_t  buf[2 * BLAKE2S_BLOCKBYTES];
+    uint8_t  buf[BLAKE2S_BLOCKBYTES];
     size_t   buflen;
     uint8_t  last_node;
   } blake2s_state;
@@ -56,7 +56,7 @@ extern "C" {
     uint64_t h[8];
     uint64_t t[2];
     uint64_t f[2];
-    uint8_t  buf[2 * BLAKE2B_BLOCKBYTES];
+    uint8_t  buf[BLAKE2B_BLOCKBYTES];
     size_t   buflen;
     uint8_t  last_node;
   } blake2b_state;

--- a/ref/blake2b-ref.c
+++ b/ref/blake2b-ref.c
@@ -316,14 +316,6 @@ int blake2b_final( blake2b_state *S, uint8_t *out, uint8_t outlen )
   if( out == NULL || outlen == 0 || outlen > BLAKE2B_OUTBYTES )
     return -1;
 
-  if( S->buflen > BLAKE2B_BLOCKBYTES )
-  {
-    blake2b_increment_counter( S, BLAKE2B_BLOCKBYTES );
-    blake2b_compress( S, S->buf );
-    S->buflen -= BLAKE2B_BLOCKBYTES;
-    memcpy( S->buf, S->buf + BLAKE2B_BLOCKBYTES, S->buflen );
-  }
-
   blake2b_increment_counter( S, S->buflen );
   blake2b_set_lastblock( S );
   memset( S->buf + S->buflen, 0, BLAKE2B_BLOCKBYTES - S->buflen ); /* Padding */

--- a/ref/blake2b-ref.c
+++ b/ref/blake2b-ref.c
@@ -284,7 +284,7 @@ int blake2b_update( blake2b_state *S, const uint8_t *in, uint64_t inlen )
   while( inlen > 0 )
   {
     size_t left = S->buflen;
-    size_t fill = 2 * BLAKE2B_BLOCKBYTES - left;
+    size_t fill = BLAKE2B_BLOCKBYTES - left;
 
     if( inlen > fill )
     {
@@ -292,8 +292,7 @@ int blake2b_update( blake2b_state *S, const uint8_t *in, uint64_t inlen )
       S->buflen += fill;
       blake2b_increment_counter( S, BLAKE2B_BLOCKBYTES );
       blake2b_compress( S, S->buf ); // Compress
-      memcpy( S->buf, S->buf + BLAKE2B_BLOCKBYTES, BLAKE2B_BLOCKBYTES ); // Shift buffer left
-      S->buflen -= BLAKE2B_BLOCKBYTES;
+      S->buflen = 0;
       in += fill;
       inlen -= fill;
     }
@@ -302,7 +301,7 @@ int blake2b_update( blake2b_state *S, const uint8_t *in, uint64_t inlen )
       memcpy( S->buf + left, in, inlen );
       S->buflen += inlen; // Be lazy, do not compress
       in += inlen;
-      inlen -= inlen;
+      inlen = 0;
     }
   }
 
@@ -327,7 +326,7 @@ int blake2b_final( blake2b_state *S, uint8_t *out, uint8_t outlen )
 
   blake2b_increment_counter( S, S->buflen );
   blake2b_set_lastblock( S );
-  memset( S->buf + S->buflen, 0, 2 * BLAKE2B_BLOCKBYTES - S->buflen ); /* Padding */
+  memset( S->buf + S->buflen, 0, BLAKE2B_BLOCKBYTES - S->buflen ); /* Padding */
   blake2b_compress( S, S->buf );
 
   for( int i = 0; i < 8; ++i ) /* Output full hash to temp buffer */

--- a/ref/blake2s-ref.c
+++ b/ref/blake2s-ref.c
@@ -274,7 +274,7 @@ int blake2s_update( blake2s_state *S, const uint8_t *in, uint64_t inlen )
   while( inlen > 0 )
   {
     size_t left = S->buflen;
-    size_t fill = 2 * BLAKE2S_BLOCKBYTES - left;
+    size_t fill = BLAKE2S_BLOCKBYTES - left;
 
     if( inlen > fill )
     {
@@ -282,8 +282,7 @@ int blake2s_update( blake2s_state *S, const uint8_t *in, uint64_t inlen )
       S->buflen += fill;
       blake2s_increment_counter( S, BLAKE2S_BLOCKBYTES );
       blake2s_compress( S, S->buf ); // Compress
-      memcpy( S->buf, S->buf + BLAKE2S_BLOCKBYTES, BLAKE2S_BLOCKBYTES ); // Shift buffer left
-      S->buflen -= BLAKE2S_BLOCKBYTES;
+      S->buflen = 0;
       in += fill;
       inlen -= fill;
     }
@@ -292,7 +291,7 @@ int blake2s_update( blake2s_state *S, const uint8_t *in, uint64_t inlen )
       memcpy( S->buf + left, in, inlen );
       S->buflen += inlen; // Be lazy, do not compress
       in += inlen;
-      inlen -= inlen;
+      inlen = 0;
     }
   }
 
@@ -316,7 +315,7 @@ int blake2s_final( blake2s_state *S, uint8_t *out, uint8_t outlen )
 
   blake2s_increment_counter( S, ( uint32_t )S->buflen );
   blake2s_set_lastblock( S );
-  memset( S->buf + S->buflen, 0, 2 * BLAKE2S_BLOCKBYTES - S->buflen ); /* Padding */
+  memset( S->buf + S->buflen, 0, BLAKE2S_BLOCKBYTES - S->buflen ); /* Padding */
   blake2s_compress( S, S->buf );
 
   for( int i = 0; i < 8; ++i ) /* Output full hash to temp buffer */

--- a/sse/blake2.h
+++ b/sse/blake2.h
@@ -44,7 +44,7 @@ extern "C" {
     uint32_t h[8];
     uint32_t t[2];
     uint32_t f[2];
-    uint8_t  buf[2 * BLAKE2S_BLOCKBYTES];
+    uint8_t  buf[BLAKE2S_BLOCKBYTES];
     size_t   buflen;
     uint8_t  last_node;
   } blake2s_state;
@@ -54,7 +54,7 @@ extern "C" {
     uint64_t h[8];
     uint64_t t[2];
     uint64_t f[2];
-    uint8_t  buf[2 * BLAKE2B_BLOCKBYTES];
+    uint8_t  buf[BLAKE2B_BLOCKBYTES];
     size_t   buflen;
     uint8_t  last_node;
   } blake2b_state;

--- a/sse/blake2b.c
+++ b/sse/blake2b.c
@@ -324,16 +324,15 @@ int blake2b_update( blake2b_state *S, const uint8_t *in, uint64_t inlen )
   while( inlen > 0 )
   {
     size_t left = S->buflen;
-    size_t fill = 2 * BLAKE2B_BLOCKBYTES - left;
+    size_t fill = BLAKE2B_BLOCKBYTES - left;
 
     if( inlen > fill )
     {
       memcpy( S->buf + left, in, fill ); // Fill buffer
-      S->buflen += fill;
+      S->buflen = BLAKE2B_BLOCKBYTES;
       blake2b_increment_counter( S, BLAKE2B_BLOCKBYTES );
       blake2b_compress( S, S->buf ); // Compress
-      memcpy( S->buf, S->buf + BLAKE2B_BLOCKBYTES, BLAKE2B_BLOCKBYTES ); // Shift buffer left
-      S->buflen -= BLAKE2B_BLOCKBYTES;
+      S->buflen = 0;
       in += fill;
       inlen -= fill;
     }
@@ -342,7 +341,7 @@ int blake2b_update( blake2b_state *S, const uint8_t *in, uint64_t inlen )
       memcpy( S->buf + left, in, inlen );
       S->buflen += inlen; // Be lazy, do not compress
       in += inlen;
-      inlen -= inlen;
+      inlen = 0;
     }
   }
 
@@ -355,17 +354,9 @@ int blake2b_final( blake2b_state *S, uint8_t *out, uint8_t outlen )
   if( outlen > BLAKE2B_OUTBYTES )
     return -1;
 
-  if( S->buflen > BLAKE2B_BLOCKBYTES )
-  {
-    blake2b_increment_counter( S, BLAKE2B_BLOCKBYTES );
-    blake2b_compress( S, S->buf );
-    S->buflen -= BLAKE2B_BLOCKBYTES;
-    memcpy( S->buf, S->buf + BLAKE2B_BLOCKBYTES, S->buflen );
-  }
-
   blake2b_increment_counter( S, S->buflen );
   blake2b_set_lastblock( S );
-  memset( S->buf + S->buflen, 0, 2 * BLAKE2B_BLOCKBYTES - S->buflen ); /* Padding */
+  memset( S->buf + S->buflen, 0, BLAKE2B_BLOCKBYTES - S->buflen ); /* Padding */
   blake2b_compress( S, S->buf );
   memcpy( out, &S->h[0], outlen );
   return 0;


### PR DESCRIPTION
This change was suggested by Kurt Roeckx during his code review.  The double-sized buffer bothered me before, but I did not see how easy it is to reduce it by 2X.  Unless I've made a mistake (warning: I make a lot!) then this patch not only simplifies the code slightly, but it also now runs slightly faster, and saves a few bytes of memory.