### PR TITLE
fix incorrect parallel hashes returned with -l

### DIFF
--- a/ref/blake2b-ref.c
+++ b/ref/blake2b-ref.c
@@ -250,7 +250,7 @@ int blake2b_final( blake2b_state *S, void *out, size_t outlen )
   uint8_t buffer[BLAKE2B_OUTBYTES] = {0};
   size_t i;
 
-  if( out == NULL || outlen < S->outlen )
+  if( out == NULL || outlen < S->outlen || BLAKE2B_OUTBYTES < outlen)
     return -1;
 
   if( blake2b_is_lastblock( S ) )
@@ -264,7 +264,7 @@ int blake2b_final( blake2b_state *S, void *out, size_t outlen )
   for( i = 0; i < 8; ++i ) /* Output full hash to temp buffer */
     store64( buffer + sizeof( S->h[i] ) * i, S->h[i] );
 
-  memcpy( out, buffer, S->outlen );
+  memcpy( out, buffer, outlen );
   secure_zero_memory(buffer, sizeof(buffer));
   return 0;
 }

--- a/ref/blake2s-ref.c
+++ b/ref/blake2s-ref.c
@@ -243,7 +243,7 @@ int blake2s_final( blake2s_state *S, void *out, size_t outlen )
   uint8_t buffer[BLAKE2S_OUTBYTES] = {0};
   size_t i;
 
-  if( out == NULL || outlen < S->outlen )
+  if( out == NULL || outlen < S->outlen || BLAKE2S_OUTBYTES < outlen)
     return -1;
 
   if( blake2s_is_lastblock( S ) )

--- a/sse/blake2b.c
+++ b/sse/blake2b.c
@@ -248,7 +248,7 @@ int blake2b_update( blake2b_state *S, const void *pin, size_t inlen )
 
 int blake2b_final( blake2b_state *S, void *out, size_t outlen )
 {
-  if( out == NULL || outlen < S->outlen )
+  if( out == NULL || outlen < S->outlen || BLAKE2B_OUTBYTES < outlen)
     return -1;
 
   if( blake2b_is_lastblock( S ) )
@@ -259,7 +259,7 @@ int blake2b_final( blake2b_state *S, void *out, size_t outlen )
   memset( S->buf + S->buflen, 0, BLAKE2B_BLOCKBYTES - S->buflen ); /* Padding */
   blake2b_compress( S, S->buf );
 
-  memcpy( out, &S->h[0], S->outlen );
+  memcpy( out, &S->h[0], outlen );
   return 0;
 }
 

--- a/sse/blake2s.c
+++ b/sse/blake2s.c
@@ -238,7 +238,7 @@ int blake2s_final( blake2s_state *S, void *out, size_t outlen )
   uint8_t buffer[BLAKE2S_OUTBYTES] = {0};
   size_t i;
 
-  if( out == NULL || outlen < S->outlen )
+  if( out == NULL || outlen < S->outlen || BLAKE2S_OUTBYTES < outlen)
     return -1;
 
   if( blake2s_is_lastblock( S ) )
@@ -252,7 +252,7 @@ int blake2s_final( blake2s_state *S, void *out, size_t outlen )
   for( i = 0; i < 8; ++i ) /* Output full hash to temp buffer */
     store32( buffer + sizeof( S->h[i] ) * i, S->h[i] );
 
-  memcpy( out, buffer, S->outlen );
+  memcpy( out, buffer, outlen );
   secure_zero_memory( buffer, sizeof(buffer) );
   return 0;
 }


### PR DESCRIPTION
commit 932be4e9 2016-06-11 caused the following
to output random values from the stack:

  b2sum -a blake2bp -l8 /dev/null

* ref/blake2b-ref.c (blake2b_final): Copy outlen bytes
rather than S->outlen, because more than S->outlen
may be specified when initializing the hash.
* sse/blake2b.c (blake2b_final): Likewise.
* sse/blake2s.c (blake2s_final): Likewise.