### PR TITLE
fix hash outbytes length

### DIFF
--- a/b2sum/b2sum.c
+++ b/b2sum/b2sum.c
@@ -254,6 +254,7 @@ int main( int argc, char **argv )
   unsigned long maxbytes = BLAKE2B_OUTBYTES;
   const char *algorithm = "BLAKE2b";
   unsigned long outbytes = 0;
+  int OUTBYTES_LEN = BLAKE2B_OUTBYTES;
   bool bsdstyle = false;
   int c, i;
   opterr = 1;
@@ -276,28 +277,24 @@ int main( int argc, char **argv )
     case 'a':
       if( 0 == strcmp( optarg, "blake2b" ) )
       {
-        unsigned char hash[BLAKE2B_OUTBYTES] = {0};
         blake2_stream = blake2b_stream;
         maxbytes = BLAKE2B_OUTBYTES;
         algorithm = "BLAKE2b";
       }
       else if ( 0 == strcmp( optarg, "blake2s" ) )
       {
-        unsigned char hash[BLAKE2S_OUTBYTES] = {0};
         blake2_stream = blake2s_stream;
         maxbytes = BLAKE2S_OUTBYTES;
         algorithm = "BLAKE2s";
       }
       else if ( 0 == strcmp( optarg, "blake2bp" ) )
       {
-        unsigned char hash[BLAKE2B_OUTBYTES] = {0};
         blake2_stream = blake2bp_stream;
         maxbytes = BLAKE2B_OUTBYTES;
         algorithm = "BLAKE2bp";
       }
       else if ( 0 == strcmp( optarg, "blake2sp" ) )
       {
-        unsigned char hash[BLAKE2S_OUTBYTES] = {0};
         blake2_stream = blake2sp_stream;
         maxbytes = BLAKE2S_OUTBYTES;
         algorithm = "BLAKE2sp";
@@ -344,6 +341,14 @@ int main( int argc, char **argv )
 
   if( optind == argc )
     argv[argc++] = (char *) "-";
+
+
+    if (0 == strcmp(algorithm, "BLAKE2s") || 0 == strcmp(algorithm, "BLAKE2sp")) {
+        OUTBYTES_LEN = BLAKE2S_OUTBYTES;
+    }
+
+
+  unsigned char hash[OUTBYTES_LEN];
 
   for( i = optind; i < argc; ++i )
   {

--- a/b2sum/b2sum.c
+++ b/b2sum/b2sum.c
@@ -254,7 +254,6 @@ int main( int argc, char **argv )
   unsigned long maxbytes = BLAKE2B_OUTBYTES;
   const char *algorithm = "BLAKE2b";
   unsigned long outbytes = 0;
-  unsigned char hash[BLAKE2B_OUTBYTES] = {0};
   bool bsdstyle = false;
   int c, i;
   opterr = 1;
@@ -277,24 +276,28 @@ int main( int argc, char **argv )
     case 'a':
       if( 0 == strcmp( optarg, "blake2b" ) )
       {
+        unsigned char hash[BLAKE2B_OUTBYTES] = {0};
         blake2_stream = blake2b_stream;
         maxbytes = BLAKE2B_OUTBYTES;
         algorithm = "BLAKE2b";
       }
       else if ( 0 == strcmp( optarg, "blake2s" ) )
       {
+        unsigned char hash[BLAKE2S_OUTBYTES] = {0};
         blake2_stream = blake2s_stream;
         maxbytes = BLAKE2S_OUTBYTES;
         algorithm = "BLAKE2s";
       }
       else if ( 0 == strcmp( optarg, "blake2bp" ) )
       {
+        unsigned char hash[BLAKE2B_OUTBYTES] = {0};
         blake2_stream = blake2bp_stream;
         maxbytes = BLAKE2B_OUTBYTES;
         algorithm = "BLAKE2bp";
       }
       else if ( 0 == strcmp( optarg, "blake2sp" ) )
       {
+        unsigned char hash[BLAKE2S_OUTBYTES] = {0};
         blake2_stream = blake2sp_stream;
         maxbytes = BLAKE2S_OUTBYTES;
         algorithm = "BLAKE2sp";

--- a/b2sum/makefile
+++ b/b2sum/makefile
@@ -6,7 +6,7 @@ NO_OPENMP_0=-fopenmp
 NO_OPENMP_1=
 CC?=gcc
 CFLAGS?=-O3 -march=native
-CFLAGS+=-std=c89 -Wall -Wextra -pedantic -Wno-long-long -I../sse
+CFLAGS+=-std=c99 -Wall -Wextra -pedantic -Wno-long-long -I../sse
 CFLAGS+=$(NO_OPENMP_$(NO_OPENMP))
 LIBS=
 #FILES=b2sum.c ../ref/blake2b-ref.c ../ref/blake2s-ref.c ../ref/blake2bp-ref.c ../ref/blake2sp-ref.c


### PR DESCRIPTION
the hash out-bytes length takes by default the `BLAKE2B_OUTBYTES` value which is `64` , I think we should set the right length to `BLAKE2S_OUTBYTES` in case if the chosen method is `blake2s` or `blake2sp`