### PR TITLE
Bitwise cast

### DIFF
--- a/neon/blake2-impl.h
+++ b/neon/blake2-impl.h
@@ -72,8 +72,8 @@ static BLAKE2_INLINE uint16_t load16( const void *src )
   return w;
 #else
   const uint8_t *p = ( const uint8_t * )src;
-  return (( uint16_t )( p[0] ) <<  0) |
-         (( uint16_t )( p[1] ) <<  8) ;
+  return ( uint16_t )((( uint32_t )( p[0] ) <<  0) |
+                      (( uint32_t )( p[1] ) <<  8));
 #endif
 }
 

--- a/ref/blake2-impl.h
+++ b/ref/blake2-impl.h
@@ -72,8 +72,8 @@ static BLAKE2_INLINE uint16_t load16( const void *src )
   return w;
 #else
   const uint8_t *p = ( const uint8_t * )src;
-  return (( uint16_t )( p[0] ) <<  0) |
-         (( uint16_t )( p[1] ) <<  8) ;
+  return ( uint16_t )((( uint32_t )( p[0] ) <<  0) |
+                      (( uint32_t )( p[1] ) <<  8));
 #endif
 }
 

--- a/sse/blake2-impl.h
+++ b/sse/blake2-impl.h
@@ -72,8 +72,8 @@ static BLAKE2_INLINE uint16_t load16( const void *src )
   return w;
 #else
   const uint8_t *p = ( const uint8_t * )src;
-  return (( uint16_t )( p[0] ) <<  0) |
-         (( uint16_t )( p[1] ) <<  8) ;
+  return ( uint16_t )((( uint32_t )( p[0] ) <<  0) |
+                      (( uint32_t )( p[1] ) <<  8));
 #endif
 }
 


### PR DESCRIPTION
Bitwise operations promote the cast to uint16_t to int. So to be consistent, first cast to uint to keep unsignedness and prevent implicit promotion. Then cast back to uint16_t after all bitwise operations are completed. 

This prevents compiler warnings, unneccessary and implicit casts and in the case of right shifting (not the case here) unexpected behaviour.

Example can be found https://wiki.sei.cmu.edu/confluence/display/c/INT02-C.+Understand+integer+conversion+rules