### PR TITLE
NEON: Use shift-shift+insert instead of shift-shift-or for vror.

### DIFF
--- a/neon/blake2b-neon.c
+++ b/neon/blake2b-neon.c
@@ -354,7 +354,7 @@ do { b0 = vcombine_u64(vget_low_u64(m0), vget_low_u64(m1)); b1 = vcombine_u64(vg
       vreinterpret_u64_u8(vext_u8(vreinterpret_u8_u64(vget_low_u64(x)), vreinterpret_u8_u64(vget_low_u64(x)), 2)), \
       vreinterpret_u64_u8(vext_u8(vreinterpret_u8_u64(vget_high_u64(x)), vreinterpret_u8_u64(vget_high_u64(x)), 2)))
 
-#define vrorq_n_u64_63(x) veorq_u64(vaddq_u64(x, x), vshrq_n_u64(x, 63))
+#define vrorq_n_u64_63(x) vsriq_n_u64(vshlq_n_u64(x, 1), x, 63)
 
 #undef G1
 #define G1(row1l,row2l,row3l,row4l,row1h,row2h,row3h,row4h,b0,b1) \

--- a/neon/blake2b-neon.c
+++ b/neon/blake2b-neon.c
@@ -354,7 +354,7 @@ do { b0 = vcombine_u64(vget_low_u64(m0), vget_low_u64(m1)); b1 = vcombine_u64(vg
       vreinterpret_u64_u8(vext_u8(vreinterpret_u8_u64(vget_low_u64(x)), vreinterpret_u8_u64(vget_low_u64(x)), 2)), \
       vreinterpret_u64_u8(vext_u8(vreinterpret_u8_u64(vget_high_u64(x)), vreinterpret_u8_u64(vget_high_u64(x)), 2)))
 
-#define vrorq_n_u64_63(x) vsriq_n_u64(vshlq_n_u64(x, 1), x, 63)
+#define vrorq_n_u64_63(x) vsliq_n_u64(vshrq_n_u64(x, 63), x, 1)
 
 #undef G1
 #define G1(row1l,row2l,row3l,row4l,row1h,row2h,row3h,row4h,b0,b1) \

--- a/neon/blake2b-round.h
+++ b/neon/blake2b-round.h
@@ -25,7 +25,7 @@
       vreinterpret_u64_u8(vext_u8(vreinterpret_u8_u64(vget_low_u64(x)), vreinterpret_u8_u64(vget_low_u64(x)), 2)), \
       vreinterpret_u64_u8(vext_u8(vreinterpret_u8_u64(vget_high_u64(x)), vreinterpret_u8_u64(vget_high_u64(x)), 2)))
 
-#define vrorq_n_u64_63(x) veorq_u64(vaddq_u64(x, x), vshrq_n_u64(x, 63))
+#define vrorq_n_u64_63(x) vsriq_n_u64(vshlq_n_u64(x, 1), x, 63)
 
 #define G1(row1l,row2l,row3l,row4l,row1h,row2h,row3h,row4h,b0,b1) \
   row1l = vaddq_u64(vaddq_u64(row1l, b0), row2l); \

--- a/neon/blake2b-round.h
+++ b/neon/blake2b-round.h
@@ -25,7 +25,7 @@
       vreinterpret_u64_u8(vext_u8(vreinterpret_u8_u64(vget_low_u64(x)), vreinterpret_u8_u64(vget_low_u64(x)), 2)), \
       vreinterpret_u64_u8(vext_u8(vreinterpret_u8_u64(vget_high_u64(x)), vreinterpret_u8_u64(vget_high_u64(x)), 2)))
 
-#define vrorq_n_u64_63(x) vsriq_n_u64(vshlq_n_u64(x, 1), x, 63)
+#define vrorq_n_u64_63(x) vsliq_n_u64(vshrq_n_u64(x, 63), x, 1)
 
 #define G1(row1l,row2l,row3l,row4l,row1h,row2h,row3h,row4h,b0,b1) \
   row1l = vaddq_u64(vaddq_u64(row1l, b0), row2l); \

--- a/neon/blake2s-neon.c
+++ b/neon/blake2s-neon.c
@@ -440,17 +440,17 @@ int blake2s_init_key( blake2s_state *S, size_t outlen, const void *key, size_t k
 			  vrev32q_u16(					\
 			  vreinterpretq_u16_u32(x)))
 
-#define vrorq_n_u32_12(x) vorrq_u32(					\
+#define vrorq_n_u32_12(x) vsliq_n_u32(					\
 			  vshrq_n_u32(x, 12),				\
-			  vshlq_n_u32(x, 20));
+			  x, 20);
 
-#define vrorq_n_u32_8(x)  vorrq_u32(					\
-			  vshrq_n_u32(x,  8),				\
-			  vshlq_n_u32(x, 24));
+#define vrorq_n_u32_8(x)  vsliq_n_u32(					\
+			  vshrq_n_u32(x, 8 ),				\
+			  x, 24);
 
-#define vrorq_n_u32_7(x)  vorrq_u32(					\
-			  vshrq_n_u32(x,  7),				\
-			  vshlq_n_u32(x, 25));
+#define vrorq_n_u32_7(x)  vsliq_n_u32(					\
+			  vshrq_n_u32(x, 7),				\
+			  x, 25);
 
 #define DIAGONALIZE(row1, row2, row3, row4)				\
   do {									\

--- a/neon/blake2s-round.h
+++ b/neon/blake2s-round.h
@@ -19,17 +19,17 @@
 			  vrev32q_u16(			\
 			  vreinterpretq_u16_u32(x)))
 
-#define vrorq_n_u32_12(x) vorrq_u32(			\
+#define vrorq_n_u32_12(x) vsliq_n_u32(			\
 			  vshrq_n_u32(x, 12),		\
-			  vshlq_n_u32(x, 20));
+			  x, 20);
 
-#define vrorq_n_u32_8(x)  vorrq_u32(			\
+#define vrorq_n_u32_8(x)  vsliq_n_u32(			\
 			  vshrq_n_u32(x,  8),		\
-			  vshlq_n_u32(x, 24));
+			  x, 24);
 
-#define vrorq_n_u32_7(x)  vorrq_u32(			\
+#define vrorq_n_u32_7(x)  vsliq_n_u32(			\
 			  vshrq_n_u32(x,  7),		\
-			  vshlq_n_u32(x, 25));
+			  x, 25);
 
 #define G1(row1,row2,row3,row4,buf) \
   row1 = vaddq_u32(row1, vaddq_u32(row2, buf)); \


### PR DESCRIPTION
These do the same thing, rotate a 64-bit vector N bytes:

shift-shift-or:
```c
    uint64x2_t tmp = vshrq_n_u64(x, N);
    x = vshlq_n_u64(x, 64 - N);
    x = vorrq_u64(x, tmp);
```

shift-shift+insert:
```c
    uint64x2_t tmp = vshrq_n_u64(x, N);
    x = vsliq_n_u64(tmp, x, 64 - N);
```

shift-add-xor (N = 63):
```c
    uint64x2_t tmp = vshrq_n_u64(x, 63);
    x = vaddq_u64(x, x);
    x = veorq_u64(x, tmp);
```
shift-add-xor actually optimizes to shift-shift-or on Clang. I
don't know about GCC, but considering that LLVM dominates GCC
in NEON codegen and usage share, I don't really care. :P

shift-shift-or and shift-shift+insert have the same cycle count,
but shift-shift+insert uses two instructions instead of 3.

I switched to the second because when ARM gives you compound
instructions, use them and save 4 bytes a piece. This adds up very
quickly.