### PR TITLE
Avoid MSVC warning C4804

### DIFF
--- a/neon/blake2.h
+++ b/neon/blake2.h
@@ -137,8 +137,8 @@ extern "C" {
 
   /* Padded structs result in a compile-time error */
   enum {
-    BLAKE2_DUMMY_1 = 1/(sizeof(blake2s_param) == BLAKE2S_OUTBYTES),
-    BLAKE2_DUMMY_2 = 1/(sizeof(blake2b_param) == BLAKE2B_OUTBYTES)
+    BLAKE2_DUMMY_1 = 1/(int)(sizeof(blake2s_param) == BLAKE2S_OUTBYTES),
+    BLAKE2_DUMMY_2 = 1/(int)(sizeof(blake2b_param) == BLAKE2B_OUTBYTES)
   };
 
   /* Streaming API */

--- a/power8/blake2.h
+++ b/power8/blake2.h
@@ -133,8 +133,8 @@ extern "C" {
 
   /* Padded structs result in a compile-time error */
   enum {
-    BLAKE2_DUMMY_1 = 1/(sizeof(blake2s_param) == BLAKE2S_OUTBYTES),
-    BLAKE2_DUMMY_2 = 1/(sizeof(blake2b_param) == BLAKE2B_OUTBYTES)
+    BLAKE2_DUMMY_1 = 1/(int)(sizeof(blake2s_param) == BLAKE2S_OUTBYTES),
+    BLAKE2_DUMMY_2 = 1/(int)(sizeof(blake2b_param) == BLAKE2B_OUTBYTES)
   };
 
   /* Streaming API */

--- a/ref/blake2.h
+++ b/ref/blake2.h
@@ -137,8 +137,8 @@ extern "C" {
 
   /* Padded structs result in a compile-time error */
   enum {
-    BLAKE2_DUMMY_1 = 1/(sizeof(blake2s_param) == BLAKE2S_OUTBYTES),
-    BLAKE2_DUMMY_2 = 1/(sizeof(blake2b_param) == BLAKE2B_OUTBYTES)
+    BLAKE2_DUMMY_1 = 1/(int)(sizeof(blake2s_param) == BLAKE2S_OUTBYTES),
+    BLAKE2_DUMMY_2 = 1/(int)(sizeof(blake2b_param) == BLAKE2B_OUTBYTES)
   };
 
   /* Streaming API */

--- a/sse/blake2.h
+++ b/sse/blake2.h
@@ -137,8 +137,8 @@ extern "C" {
 
   /* Padded structs result in a compile-time error */
   enum {
-    BLAKE2_DUMMY_1 = 1/(sizeof(blake2s_param) == BLAKE2S_OUTBYTES),
-    BLAKE2_DUMMY_2 = 1/(sizeof(blake2b_param) == BLAKE2B_OUTBYTES)
+    BLAKE2_DUMMY_1 = 1/(int)(sizeof(blake2s_param) == BLAKE2S_OUTBYTES),
+    BLAKE2_DUMMY_2 = 1/(int)(sizeof(blake2b_param) == BLAKE2B_OUTBYTES)
   };
 
   /* Streaming API */


### PR DESCRIPTION
Fixes warnings like

 blake2.h(140): warning C4804: '/': unsafe use of type 'bool' in operation
 blake2.h(141): warning C4804: '/': unsafe use of type 'bool' in operation